### PR TITLE
Fix MPD not using app id in default config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mprisence"
 description = "A Discord Rich Presence client for MPRIS-compatible media players with support for album art."
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Phusit Somboonyingsuk"]
 readme = "README.md"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,7 +10,7 @@ arch=("x86_64")
 provides=("mprisence")
 conflicts=("mprisence")
 source=("https://github.com/phusitsom/mprisence/releases/download/v$pkgver/mprisence-$pkgver-x86_64.tar.gz" "https://raw.githubusercontent.com/phusitsom/mprisence/main/LICENSE" "https://raw.githubusercontent.com/phusitsom/mprisence/main/systemd/mprisence.service")
-sha256sums=('8a44d66c2cd80b2a0567882a0944447cc213618e7ce261d55f7e451e22938f72'
+sha256sums=('aef9e84df69888c43a27fe619b0a9c925c15e53cfc7823f5ccf14d99b7301faa'
 	'2efd06eb77e15171ec8727caece105c68fcf253f57d5af76d7964c69f16fbb7d'
 	'8103053db7f9850d775785db8a56461a4440220b231144899bf8da38a0f7363c')
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Phusit Somboonyingsuk
 
 pkgname=mprisence
-pkgver=0.2.1
+pkgver=0.2.2
 pkgrel=1
 pkgdesc="A Discord Rich Presence client for MPRIS-compatible media players with support for album art."
 url="https://github.com/phusitsom/mprisence"

--- a/config/default.toml
+++ b/config/default.toml
@@ -62,6 +62,11 @@ app_id = "1126153268486213672"
 icon = "https://www.musicpd.org/logo.png"
 allow_streaming = true
 
+[player.music_player_daemon]
+app_id = "1126153268486213672"
+icon = "https://www.musicpd.org/logo.png"
+allow_streaming = true
+
 
 [player.clementine]
 app_id = "1125075725473562735"


### PR DESCRIPTION
The player identity for MPD is `Music Player Daemon` not `mpd`