### PR TITLE
Mention `mprisence-bin` for AUR installation methods in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ yay -S mprisence
 
 # Or, install the latest development version
 yay -S mprisence-git
+
+# Or without building from source
+yay -S mprisence-bin
 ```
 
 #### Nix (NixOS, Linux)


### PR DESCRIPTION
Hi, I've packaged the prebuilt version of this on the AUR @ [mprisence-bin](https://aur.archlinux.org/packages/mprisence-bin), so I've added mention of it to the README.