### PR TITLE
fix: discord socket detection method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,12 +718,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doctest-file"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,19 +1562,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interprocess"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
-dependencies = [
- "doctest-file",
- "libc",
- "recvmsg",
- "widestring",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,7 +1926,6 @@ dependencies = [
  "handlebars_misc_helpers",
  "image",
  "imgbb",
- "interprocess",
  "lofty",
  "log",
  "mime_guess",
@@ -2429,12 +2409,6 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
-
-[[package]]
-name = "recvmsg"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -3753,12 +3727,6 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ base64 = "0.22.1"
 lofty = "0.24.0"
 semver = "1.0.28"
 walkdir = "2.5.0"
-interprocess = "2.4.2"
 regex = "1"
 catbox = "0.8.2"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,9 +1,6 @@
 use log::{debug, trace};
-use std::io::ErrorKind;
 use std::path::PathBuf;
 
-use interprocess::local_socket::{prelude::*, GenericFilePath, Stream};
-use std::collections::HashMap;
 use std::env;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -31,60 +28,26 @@ pub fn is_discord_running() -> bool {
                     .join(format!("discord-ipc-{}", i))
             }));
 
-        let mut successful_path: Option<PathBuf> = None;
-        let mut error_counts: HashMap<ErrorKind, usize> = HashMap::new();
-
         for socket_path in potential_paths {
-            let name = match socket_path.clone().to_fs_name::<GenericFilePath>() {
-                Ok(n) => n,
-                Err(e) => {
-                    trace!(
-                        "Failed to create IPC socket name from path {:?}: {}",
-                        socket_path,
-                        e
-                    );
-                    continue;
-                }
-            };
-
-            match Stream::connect(name) {
-                Ok(conn) => {
-                    drop(conn);
-                    successful_path = Some(socket_path);
-                    DISCORD_CONNECTION_ERROR_LOGGED.store(false, Ordering::Relaxed);
-                    break;
-                }
-                Err(e) => {
-                    *error_counts.entry(e.kind()).or_insert(0) += 1;
-                }
+            if socket_path.exists() {
+                trace!("IPC socket found at {:?}", socket_path);
+                DISCORD_CONNECTION_ERROR_LOGGED.store(false, Ordering::Relaxed);
+                return true;
             }
         }
 
-        if let Some(path) = successful_path {
-            trace!("Successfully connected via {:?}.", path);
-            true
-        } else {
-            debug!("Could not connect to Discord IPC socket. Assuming not running.");
-            if !error_counts.is_empty() {
-                let error_summary = error_counts
-                    .iter()
-                    .map(|(kind, count)| format!("{:?}: {}", kind, count))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                debug!("Connection errors encountered: [{}]", error_summary);
-            }
+        debug!("No Discord IPC socket found. Assuming not running.");
 
-            if !DISCORD_CONNECTION_ERROR_LOGGED.load(Ordering::Relaxed)
-                && DISCORD_CONNECTION_ERROR_LOGGED
-                    .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
-                    .is_ok()
-            {
-                log::info!(
-                    "Could not connect to Discord IPC socket. Presence updates will be disabled until connection succeeds."
-                );
-            }
-            false
+        if !DISCORD_CONNECTION_ERROR_LOGGED.load(Ordering::Relaxed)
+            && DISCORD_CONNECTION_ERROR_LOGGED
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+        {
+            log::info!(
+                "Could not find Discord IPC socket. Presence updates will be disabled until connection succeeds."
+            );
         }
+        false
     } else if let Some(lock_path) = get_discord_lock_path() {
         match std::fs::symlink_metadata(&lock_path) {
             Ok(_) => {


### PR DESCRIPTION
## Overview

Changed `is_discord_running()` to check for the existence of the IPC socket file instead of establishing a TCP connection and immediately dropping it.

## Reason

`is_discord_running()` previously called `Stream::connect()` on each candidate socket path and immediately dropped the connection. This caused the RPC server (Discord's own or alternative implementations like [rsRPC](https://github.com/SpikeHD/rsRPC)) to accept a connection that sends no data, triggering unnecessary error handling paths (e.g., sending an empty activity that clears the current presence).

Since the function only needs to verify that an IPC socket exists (not that a full handshake succeeds), checking for the socket file with `Path::exists()` is sufficient and avoids spurious connections.