### PR TITLE
fix(presence): send configured player name as Discord activity name

### DIFF
--- a/src/presence.rs
+++ b/src/presence.rs
@@ -1395,6 +1395,12 @@ impl Presence {
             .activity_type(framing.activity_type.into())
             .status_display_type(framing.status_display_type.into());
 
+        if let Some(name) = framing.player_config.name.as_deref() {
+            if !name.is_empty() {
+                activity = activity.name(name);
+            }
+        }
+
         if !framing.texts.details.is_empty() {
             activity = activity.details(&framing.texts.details);
         }


### PR DESCRIPTION
Closes #96 

## What

Use the configured player `name` as the Discord activity name so the presence header shows it instead of the default application name.

## Change

When `player_config.name` is non-empty, call `activity.name(name)` before the existing fields are set. Six lines; no behavior change when no `name` is configured.

```rust
# src/presence.rs
if let Some(name) = framing.player_config.name.as_deref() {
    if !name.is_empty() {
        activity = activity.name(name);
    }
}
```

### Impact
- Default-app players with a configured name: header now shows the name.
- Bundled web-player presets (dedicated app IDs): name equals their registered app name, so no visible change.
- Local players: no name configured, unchanged.