### PR TITLE
fix: allow using Discord application name for player activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,17 @@ show_icon = true
 Bundled presets keep separate Discord application IDs and define an explicit
 `name` for the displayed activity and `{{{player}}}` template value.
 
+Use the name registered for a custom Discord application instead of bundled
+player names:
+
+```toml
+[player.default]
+app_id = "YOUR_DISCORD_APP_ID"
+use_app_name = true
+```
+
+`use_app_name` defaults to `false`.
+
 Restrict discovery with the same selectors, or by resolved preset/site key:
 
 ```toml

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -211,6 +211,7 @@
 #   match_pattern / match_patterns: Match normalized MPRIS identity or canonical bus name.
 #       Prefix with identity: or bus: to restrict a pattern to one field.
 #   name: Discord activity name and {{{player}}} template value
+#   use_app_name: Omit the activity name so Discord uses the name registered for app_id
 #   ignore: Don't show rich presence for this player
 #   ignore_unmatched: Only in [player.default]. Hide players with no matching [player.*] entry.
 #   app_id: Discord application ID (get yours: https://discord.com/developers/docs/quick-start/overview-of-apps)
@@ -252,6 +253,11 @@
 # app_id = "YOUR_DISCORD_APP_ID"
 # icon = "https://www.musicpd.org/logo.png"
 # allow_streaming = true
+
+# Use Discord's registered application name instead of the player preset name.
+# [player.default]
+# app_id = "YOUR_DISCORD_APP_ID"
+# use_app_name = true
 
 # For the full list of bundled local players and web players, see config.default.toml
 # on GitHub: https://github.com/lazykern/mprisence/blob/main/config/config.default.toml

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -73,6 +73,7 @@ pub const DEFAULT_TIME_AS_ELAPSED: bool = false;
 pub const DEFAULT_IMGBB_EXPIRATION: u64 = 86400;
 
 pub const DEFAULT_PLAYER_APP_ID: &str = "1121632048155742288";
+pub const DEFAULT_PLAYER_USE_APP_NAME: bool = false;
 pub const DEFAULT_PLAYER_ICON: &str =
     "https://raw.githubusercontent.com/lazykern/mprisence/main/assets/icon.png";
 pub const DEFAULT_PLAYER_IGNORE: bool = false;
@@ -1790,6 +1791,9 @@ pub struct PlayerConfigLayer {
 
     #[serde(default)]
     pub override_activity_type: Option<ActivityType>,
+
+    #[serde(default)]
+    pub use_app_name: Option<bool>,
 }
 
 impl PlayerConfigLayer {
@@ -1829,6 +1833,9 @@ impl PlayerConfigLayer {
         if let Some(value) = self.override_activity_type {
             base.override_activity_type = Some(value);
         }
+        if let Some(value) = self.use_app_name {
+            base.use_app_name = value;
+        }
 
         base
     }
@@ -1845,6 +1852,7 @@ impl PlayerConfigLayer {
         self.allow_streaming = other.allow_streaming.or(self.allow_streaming);
         self.status_display_type = other.status_display_type.or(self.status_display_type);
         self.override_activity_type = other.override_activity_type.or(self.override_activity_type);
+        self.use_app_name = other.use_app_name.or(self.use_app_name);
     }
 }
 
@@ -1873,6 +1881,14 @@ pub struct PlayerConfig {
 
     #[serde(default)]
     pub override_activity_type: Option<ActivityType>,
+
+    // If true, the player config's name is ignored and the app name is used instead.
+    #[serde(default = "default_player_use_app_name")]
+    pub use_app_name: bool,
+}
+
+fn default_player_use_app_name() -> bool {
+    DEFAULT_PLAYER_USE_APP_NAME
 }
 
 fn default_player_ignore() -> bool {
@@ -1903,6 +1919,7 @@ impl Default for PlayerConfig {
     fn default() -> PlayerConfig {
         PlayerConfig {
             name: None,
+            use_app_name: default_player_use_app_name(),
             ignore: default_player_ignore(),
             app_id: default_player_app_id(),
             icon: default_player_icon(),

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -1748,7 +1748,7 @@ mod tests {
         }
     }
 
-    fn activity_payload(name: Option<&str>) -> serde_json::Value {
+    fn activity_payload(name: Option<&str>, use_app_name: bool) -> serde_json::Value {
         let texts = ActivityTexts {
             details: "Track".to_string(),
             state: "Artist".to_string(),
@@ -1757,6 +1757,7 @@ mod tests {
         };
         let player_config = PlayerConfig {
             name: name.map(str::to_string),
+            use_app_name,
             ..PlayerConfig::default()
         };
         let framing = ActivityFraming {
@@ -1820,15 +1821,22 @@ mod tests {
 
     #[test]
     fn activity_uses_nonempty_configured_name() {
-        let payload = activity_payload(Some("VLC Media Player"));
+        let payload = activity_payload(Some("VLC Media Player"), false);
 
         assert_eq!(payload["name"], "VLC Media Player");
     }
 
     #[test]
     fn activity_omits_missing_or_empty_name() {
-        assert!(activity_payload(None).get("name").is_none());
-        assert!(activity_payload(Some("")).get("name").is_none());
+        assert!(activity_payload(None, false).get("name").is_none());
+        assert!(activity_payload(Some(""), false).get("name").is_none());
+    }
+
+    #[test]
+    fn activity_omits_configured_name_when_using_app_name() {
+        let payload = activity_payload(Some("Strawberry"), true);
+
+        assert!(payload.get("name").is_none());
     }
 
     #[test]

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -88,6 +88,11 @@ fn resolve_status_display_type(player_config: &PlayerConfig) -> StatusDisplayTyp
 }
 
 fn configured_activity_name(player_config: &PlayerConfig) -> Option<&str> {
+    // If the player config has `use_app_name = true`, the app name is used instead of the name.
+    if player_config.use_app_name {
+        return None;
+    }
+
     player_config
         .name
         .as_deref()


### PR DESCRIPTION
Fixes https://github.com/lazykern/mprisence/issues/98